### PR TITLE
Add some simple URL checking

### DIFF
--- a/src/remote_decks/parseRemoteDeck.py
+++ b/src/remote_decks/parseRemoteDeck.py
@@ -9,6 +9,8 @@ def getRemoteDeck(url):
 
     # Get remote page
     # TODO Validate url before getting data
+    if url.startswith('https://docs.google.com/') and not url.endswith('pub'):
+        raise Exception("Use the Publish link, not the Sharing link")
     pageType = _determinePageType(url)
     deck = None
     if pageType == "html":


### PR DESCRIPTION
A very basic test to make sure the URL supplied is from a published Google doc, not from the "Share with others" link. Even though the README clearly says it has to be published, some users might be a little eager to just try it out and will get quite frustrated that it doesn't seem to work (don't ask me how I know...)