### PR TITLE
Bug/#76 cannot create note model is empty

### DIFF
--- a/orgVersion.txt
+++ b/orgVersion.txt
@@ -1,1 +1,1 @@
-ORG_VERSION="v1.7.3"
+ORG_VERSION="v1.7.5"

--- a/orgVersion.txt
+++ b/orgVersion.txt
@@ -1,1 +1,1 @@
-ORG_VERSION="v1.7.2"
+ORG_VERSION="v1.7.3"


### PR DESCRIPTION
Update org_to_anki to newer version.

Failure to create a single notes note just results in a warning instead on a total failure