### PR TITLE
Shortcut implementation for QTActions

### DIFF
--- a/src/__init__.py
+++ b/src/__init__.py
@@ -5,6 +5,7 @@ try:
     from aqt import mw
     # import the "show info" tool from utils.py
     from aqt.utils import showInfo
+    from aqt.utils import shortcut
     # import all of the Qt GUI library
     from aqt.qt import *
     from aqt.importing import ImportDialog
@@ -87,15 +88,18 @@ if (QAction != None and mw != None):
 
     # set it to call testFunction when it's clicked
     remoteDeckAction = QAction("Add new remote Deck", mw)
+    remoteDeckAction.setShortcut(QKeySequence("Ctrl+Shift+V"))
     remoteDeckAction.triggered.connect(addDeck)
     remoteDecksSubMenu.addAction(remoteDeckAction)
 
     # Sync remote decks
     syncDecksAction = QAction("Sync remote decks", mw)
+    syncDecksAction.setShortcut(QKeySequence("Ctrl+Shift+S"))
     syncDecksAction.triggered.connect(syncDecks)
     remoteDecksSubMenu.addAction(syncDecksAction)
 
     # Remove remote deck
     removeRemoteDeck = QAction("Remove remote deck", mw)
+    removeRemoteDeck.setShortcut(QKeySequence("Ctrl+Shift+D"))
     removeRemoteDeck.triggered.connect(removeRemote)
     remoteDecksSubMenu.addAction(removeRemoteDeck)


### PR DESCRIPTION
Implemented shortcuts for the three QTActions with QTShortcut

The shortcuts were chosen like this:
"Add new remote deck" Ctrl+Shift+V, similar to Ctrl V to paste something
"Sync remote decks" Ctrl+Shift+S, S for syncing
"Remove remote deck" Ctrl+Shift+D, D for deleting

You can change the shortcuts if you don't like them.